### PR TITLE
Fix crash due to mishandling of strings

### DIFF
--- a/src/cplusplus/CString.cpp
+++ b/src/cplusplus/CString.cpp
@@ -121,12 +121,12 @@ void String::trim()
 	memset(newText, 0, capacity);
 	strcpy(newText, text);
 	
-	while (isspace(text[start]))
+	while (start <= end && isspace(text[start]))
 	{
 		start++;
 	}
 	
-	while (isspace(text[end]))
+	while (end >= 0 && isspace(text[end]))
 	{
 		end--;
 	}


### PR DESCRIPTION
I noticed that the game kept crashing because the String::trim() function can't handle strings that are only whitespace. The basic checks I added probably aren't the best way to fix this, but at least they seem to work. The weird thing is that I don't remember having this problem when I ran the game on other systems, but on OpenBSD it would crash most of the times that I tried to run it (and if it happened to actually run correctly, it would almost always crash while trying to load a saved game). I guess the function only has to work with whitespace-only strings in some specific cases that don't always occur.