### PR TITLE
Fix out-of-bounds memory access

### DIFF
--- a/src/entities/structures.cpp
+++ b/src/entities/structures.cpp
@@ -90,8 +90,6 @@ void drawStructure(bool transparent)
 			continue;
 		}
 		
-		lightMap = bsp->lightmapTextures[structure->model->lightmapID[i]];
-		
 		fade = min(textureSpec->lightLevel, (structure->health / 500));
 		
 		glPushMatrix();
@@ -158,6 +156,7 @@ void drawStructure(bool transparent)
 					}
 					else if ((structure->model->lightmapID[i] >= 0) && (!textureSpec->bright))
 					{
+						lightMap = bsp->lightmapTextures[structure->model->lightmapID[i]];
 						glBindTexture(GL_TEXTURE_2D, lightMap);
 					}
 					else


### PR DESCRIPTION
There is a check `structure->model->lightmapID[i] >= 0` before actually using `lightMap`, but since `lightMap` is already set to `bsp->lightmapTextures[structure->model->lightmapID[i]]` before that, there is an out-of-bounds memory access when `structure->model->lightmapID[i]` is less than 0. Since `lightMap` isn't used anywhere else, it can simply be moved after that check. This was found with `-fsanitize=address`.